### PR TITLE
Check out runner when building main image

### DIFF
--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -25,7 +25,9 @@ jobs:
       - name: Check out docker files
         uses: actions/checkout@v4
         with:
-          sparse-checkout: docker
+          sparse-checkout:
+            - docker
+            - runner
 
       - name: Run file diff checking image
         id: changed-docker-files


### PR DESCRIPTION
Docker workflow for main image failed now that it also triggers a runner build. Added missing checkout of runner files to the workflow.