### PR TITLE
Plot points and smoothed lines for ages

### DIFF
--- a/test.R
+++ b/test.R
@@ -4,6 +4,7 @@
 library(coda)
 library(eiPack)
 library(sf)
+library(stringr)
 source("betas.R")
 source("present.R")
 source("prepare_results.R")
@@ -45,4 +46,4 @@ print(construct_contingency(results.52, betas.MD(beta.sims.MD(ei.52, p52, meride
 
 boxplot <- boxplotMD(beta.sims.MD(ei.52, p52), 1851, 1852)
 ridge <- ridgelineMD(beta.sims.MD(ei.52, p52), 1851, 1852)
-map <- create_map(1851, results.52$Free_Soil_vote_in_1852 / results.52$total_1852)
+map <- create_map(1851, (results.1851 %>% filter(! str_detect(town, "^Weighted")))$Free_Soil)


### PR DESCRIPTION
Replace age-distribution histogram plots with point and smoothed-line plots.

Identify age-distribution peaks using the smoothed-line estimate.

Change the  vote-share map in the test script to use a single-year results tibble.